### PR TITLE
Change app layout to display grid

### DIFF
--- a/client/src/components/elements/layout.js
+++ b/client/src/components/elements/layout.js
@@ -10,11 +10,17 @@ export default function Layout({ children, location }) {
   useQuery(CURRENT_USER_QUERY)
 
   return (
-    <>
+    <div
+      style={{
+        display: `grid`,
+        gridTemplateRows: `auto 1fr auto`,
+        minHeight: `100vh`,
+      }}
+    >
       <Header location={location} />
-      <main style={{ minHeight: `100vh` }}>{children}</main>
+      <main>{children}</main>
       <Footer />
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
Remove need to set a minHeight style on main. Set a minHeight of 1fr on main and 100vh on entire app instead. That way when handling a page loading state, main maintains a 1fr size.